### PR TITLE
Add daily Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot Auto-Merge
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Approve and merge Dependabot PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Auto-merge Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --author "app/dependabot" \
+            --state open \
+            --json number,title \
+            --jq '.[].number')
+
+          if [ -z "$prs" ]; then
+            echo "No open Dependabot PRs found."
+            exit 0
+          fi
+
+          for pr in $prs; do
+            echo "Processing PR #$pr..."
+            gh pr review "$pr" --repo "$GITHUB_REPOSITORY" --approve || true
+            gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --squash --auto || true
+          done


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs daily at 08:00 UTC
- Automatically approves and squash-merges all open Dependabot PRs
- Can also be triggered manually via `workflow_dispatch`

## How it works

The workflow uses `GITHUB_TOKEN` (no extra secrets needed) to:
1. List all open PRs authored by `app/dependabot`
2. Approve each one
3. Merge with `--auto` flag (waits for required checks if any are configured)